### PR TITLE
feat: Implement Coexisting Click-to-Move and Drag-and-Drop

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -586,7 +586,6 @@ body.light-theme .difficulty-button.difficulty-learn.selected {
     position: absolute;
     z-index: 1000; /* High z-index to float above everything */
     pointer-events: none; /* Allows click events to pass through to squares underneath */
-    transform: scale(1.2); /* Make it slightly larger */
     box-shadow: 0px 5px 15px rgba(0,0,0,0.3); /* Add a shadow for depth */
     /* Ensure image/text inside scales correctly if needed, but transform on the element itself should handle it */
     /* If it's an img tag, its width/height might need to be explicitly set or handled by parent's display context */


### PR DESCRIPTION
This commit introduces two distinct interaction models for moving chess pieces, allowing you to choose your preferred method:

1.  **Click-to-Move:**
    *   Click a piece to select it (it follows the mouse).
    *   Click a legal square to move the piece.
    *   Clicking the selected piece again or an illegal square deselects it.

2.  **Drag-and-Drop:**
    *   Click and hold a piece, then drag it to a legal square.
    *   Release the mouse button to place the piece.

Key changes:
- Modified `scripts.js` to support both interaction models.
- Reinstated and adapted `startDrag`, `handleDrag`, `endDrag` functions for drag-and-drop.
- Updated `handleSquareClick` to manage click-to-move and to prevent conflicts with drag-and-drop using an `isDraggingViaMouseDown` flag.
- Both systems now use a shared `pickedUpPieceElement` (a clone of the piece being moved) and the `updatePickedUpPiecePosition` function for mouse following.
- The original piece on the board is hidden while its clone follows the cursor.
- CSS for `.picked-up-piece` in `styles.css` was adjusted to remove scaling, so pieces remain their original size during selection and movement.
- Touch event handlers (`handleTouchStart`, `handleTouchMove`, `handleTouchEnd`) have been adapted to mirror the mouse-based drag-and-drop logic.